### PR TITLE
add null check at unloaded event

### DIFF
--- a/MonacoEditorComponent/CodeEditor.cs
+++ b/MonacoEditorComponent/CodeEditor.cs
@@ -140,7 +140,10 @@ namespace Monaco
             _parentAccessor?.Dispose();
             _parentAccessor = null;
             Options.PropertyChanged -= Options_PropertyChanged;
-            _themeListener.ThemeChanged -= _themeListener_ThemeChanged;
+
+            if(_themeListener != null)
+                _themeListener.ThemeChanged -= _themeListener_ThemeChanged;
+
             _themeListener = null;
             UnregisterPropertyChangedCallback(RequestedThemeProperty, _themeToken);
             _keyboardListener = null;

--- a/MonacoEditorComponent/CodeEditor.cs
+++ b/MonacoEditorComponent/CodeEditor.cs
@@ -140,11 +140,10 @@ namespace Monaco
             _parentAccessor?.Dispose();
             _parentAccessor = null;
             Options.PropertyChanged -= Options_PropertyChanged;
-
-            if(_themeListener != null)
-                _themeListener.ThemeChanged -= _themeListener_ThemeChanged;
-
+            
+            _themeListener?.ThemeChanged -= _themeListener_ThemeChanged;
             _themeListener = null;
+            
             UnregisterPropertyChangedCallback(RequestedThemeProperty, _themeToken);
             _keyboardListener = null;
             _model = null;


### PR DESCRIPTION
If the control is collapsed and then unloaded the themechanged call throws an exception.

-> Delegate to an instance method cannot have null 'this'.
