### PR TITLE
Upgrade to C# 8.0 and disable NRT during type generation

### DIFF
--- a/GenerateMonacoTypings/generate-typings.ps1
+++ b/GenerateMonacoTypings/generate-typings.ps1
@@ -48,7 +48,7 @@ Expand-Archive "TypedocConverter.zip" -DestinationPath .
 
 # Now run TypedocConverter on our monaco.json
 
-Invoke-Expression ".\TypedocConverter.exe --inputfile monaco.json --splitfiles true --outputdir ../$env:npm_package_config_outdir --promise-type WinRT"
+Invoke-Expression ".\TypedocConverter.exe --inputfile monaco.json --splitfiles true --outputdir ../$env:npm_package_config_outdir --promise-type WinRT --nrt-disabled true"
 
 Pop-Location
 

--- a/GenerateMonacoTypings/package.json
+++ b/GenerateMonacoTypings/package.json
@@ -13,10 +13,10 @@
     "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0/Windows_x64.zip"
   },
   "dependencies": {
-    "monaco-editor": "0.20.0"
+    "monaco-editor": "0.21.2"
   },
   "devDependencies": {
-    "typedoc": "^0.17.3",
-    "typescript": "^3.8.3"
+    "typedoc": "^0.19.2",
+    "typescript": "^4.0.5"
   }
 }

--- a/GenerateMonacoTypings/package.json
+++ b/GenerateMonacoTypings/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "config": {
     "outdir": "../MonacoEditorComponent",
-    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v1.6/Windows_x64.zip"
+    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0-pre1/Windows_x64.zip"
   },
   "dependencies": {
     "monaco-editor": "0.20.0"

--- a/GenerateMonacoTypings/package.json
+++ b/GenerateMonacoTypings/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "config": {
     "outdir": "../MonacoEditorComponent",
-    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0-pre2/Windows_x64.zip"
+    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0/Windows_x64.zip"
   },
   "dependencies": {
     "monaco-editor": "0.20.0"

--- a/GenerateMonacoTypings/package.json
+++ b/GenerateMonacoTypings/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "config": {
     "outdir": "../MonacoEditorComponent",
-    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0-pre1/Windows_x64.zip"
+    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0-pre2/Windows_x64.zip"
   },
   "dependencies": {
     "monaco-editor": "0.20.0"

--- a/GenerateMonacoTypings/package.json
+++ b/GenerateMonacoTypings/package.json
@@ -10,13 +10,13 @@
   "license": "MIT",
   "config": {
     "outdir": "../MonacoEditorComponent",
-    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.0/Windows_x64.zip"
+    "typedocConverter": "https://github.com/hez2010/TypedocConverter/releases/download/v2.2/Windows_x64.zip"
   },
   "dependencies": {
-    "monaco-editor": "0.21.2"
+    "monaco-editor": "0.22.3"
   },
   "devDependencies": {
-    "typedoc": "^0.19.2",
-    "typescript": "^4.0.5"
+    "typedoc": "^0.20.26",
+    "typescript": "^4.1.5"
   }
 }

--- a/MonacoEditorComponent/MonacoEditorComponent.csproj
+++ b/MonacoEditorComponent/MonacoEditorComponent.csproj
@@ -15,6 +15,7 @@
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>8.0</LangVersion>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
   </PropertyGroup>

--- a/MonacoEditorTestApp/MonacoEditorTestApp.csproj
+++ b/MonacoEditorTestApp/MonacoEditorTestApp.csproj
@@ -15,6 +15,7 @@
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>8.0</LangVersion>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <PackageCertificateKeyFile>MonacoEditorTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>

--- a/install-dependencies.ps1
+++ b/install-dependencies.ps1
@@ -2,7 +2,7 @@
 # install dependencies into the project directory before building.
 
 # Reference to Monaco Version to Use in the Package
-$monaco_version = "0.21.2"
+$monaco_version = "0.22.3"
 
 # ------------------------
 $monaco_tgz_url = "https://registry.npmjs.org/monaco-editor/-/monaco-editor-$monaco_version.tgz"

--- a/install-dependencies.ps1
+++ b/install-dependencies.ps1
@@ -2,7 +2,7 @@
 # install dependencies into the project directory before building.
 
 # Reference to Monaco Version to Use in the Package
-$monaco_version = "0.20.0"
+$monaco_version = "0.21.2"
 
 # ------------------------
 $monaco_tgz_url = "https://registry.npmjs.org/monaco-editor/-/monaco-editor-$monaco_version.tgz"


### PR DESCRIPTION
- Upgrade to C# 8.0 so that the new switch expression can be used in project
- Disable NRT in type generation