### PR TITLE
Fix crashes in Release build

### DIFF
--- a/MonacoEditorComponent/Monaco/Editor/IModelDeltaDecoration.cs
+++ b/MonacoEditorComponent/Monaco/Editor/IModelDeltaDecoration.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Monaco.Helpers;
+using Newtonsoft.Json;
 
 namespace Monaco.Editor
 {
@@ -10,7 +11,7 @@ namespace Monaco.Editor
         [JsonProperty("options")]
         public IModelDecorationOptions Options { get; private set; }
 
-        [JsonProperty("range")]
+        [JsonProperty("range"), JsonConverter(typeof(InterfaceToClassConverter<IRange, Range>))]
         public IRange Range { get; private set; }
 
         public IModelDeltaDecoration(IRange range, IModelDecorationOptions options)

--- a/MonacoEditorComponent/Monaco/Helpers/CssGlyphStyle.cs
+++ b/MonacoEditorComponent/Monaco/Helpers/CssGlyphStyle.cs
@@ -1,5 +1,8 @@
-﻿namespace Monaco.Helpers
+﻿using Newtonsoft.Json;
+
+namespace Monaco.Helpers
 {
+    [JsonConverter(typeof(CssStyleConverter))]
     public sealed class CssGlyphStyle : ICssStyle
     {
         public System.Uri GlyphImage { get; set; }

--- a/MonacoEditorComponent/Monaco/Helpers/CssInlineStyle.cs
+++ b/MonacoEditorComponent/Monaco/Helpers/CssInlineStyle.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using Newtonsoft.Json;
+using System.Text;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Media;
 
@@ -7,6 +8,7 @@ namespace Monaco.Helpers
     /// <summary>
     /// Inline styles modify the text style itself and are useful for manipulating the colors and styles of text to indicate conditions.
     /// </summary>
+    [JsonConverter(typeof(CssStyleConverter))]
     public sealed class CssInlineStyle : ICssStyle
     {
         public TextDecoration TextDecoration { get; set; }

--- a/MonacoEditorComponent/Monaco/Helpers/CssLineStyle.cs
+++ b/MonacoEditorComponent/Monaco/Helpers/CssLineStyle.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Text;
 using Windows.UI.Xaml.Media;
 
@@ -8,6 +9,7 @@ namespace Monaco.Helpers
     /// Simple Proxy to general CSS Line Styles.
     /// Line styles are overlayed behind text in the editor and are useful for highlighting sections of text efficiently
     /// </summary>
+    [JsonConverter(typeof(CssStyleConverter))]
     public sealed class CssLineStyle : ICssStyle
     {
         public SolidColorBrush BackgroundColor { get; set; }

--- a/MonacoEditorComponent/Monaco/Helpers/ICssStyle.cs
+++ b/MonacoEditorComponent/Monaco/Helpers/ICssStyle.cs
@@ -4,7 +4,6 @@ using System.Linq;
 
 namespace Monaco.Helpers
 {
-    [JsonConverter(typeof(CssStyleConverter))]
     public interface ICssStyle
     {
         uint Id { get; }

--- a/MonacoEditorComponent/MonacoEditorComponent.csproj
+++ b/MonacoEditorComponent/MonacoEditorComponent.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>MonacoEditorComponent</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -252,18 +252,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TypeScript.MSBuild">
-      <Version>3.8.3</Version>
+      <Version>4.3.5</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx">
-      <Version>5.0.0</Version>
+      <Version>5.1.0</Version>
     </PackageReference>
     <PackageReference Include="ObservableVector">
       <Version>2.1.0</Version>

--- a/MonacoEditorTestApp/MainPage.xaml.cs
+++ b/MonacoEditorTestApp/MainPage.xaml.cs
@@ -360,7 +360,7 @@ namespace MonacoEditorTestApp
             }
             else
             {
-                //Editor.Markers.Clear();
+                Editor.Markers.Clear();
                 await Editor.SetModelMarkersAsync("CodeEditor", Array.Empty<IMarkerData>());
 
                 _actionProvider.IsOn = false;

--- a/MonacoEditorTestApp/MonacoEditorTestApp.csproj
+++ b/MonacoEditorTestApp/MonacoEditorTestApp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>MonacoEditorTestApp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -138,7 +138,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.12</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Seems that it's a bug of .NET Native compiler. It failed to propagate JsonConverter from interface to implementation classes.

Also, I bumped some dependencies.

Fixes #60.